### PR TITLE
Seperate x86-64 v1 and v3 versions

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,8 +8,12 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_64_microarch_level1:
+        CONFIG: linux_64_microarch_level1
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_microarch_level3:
+        CONFIG: linux_64_microarch_level3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_:

--- a/.ci_support/linux_64_microarch_level1.yaml
+++ b/.ci_support/linux_64_microarch_level1.yaml
@@ -1,0 +1,44 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+gmp:
+- '6'
+libblas:
+- 3.9.* *netlib
+libcblas:
+- 3.9.* *netlib
+liblapack:
+- 3.9.* *netlib
+metis:
+- 5.1.0
+microarch_level:
+- '1'
+mpfr:
+- '4'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/linux_64_microarch_level3.yaml
+++ b/.ci_support/linux_64_microarch_level3.yaml
@@ -32,6 +32,8 @@ liblapack:
 - 3.9.* *netlib
 metis:
 - 5.1.0
+microarch_level:
+- '3'
 mpfr:
 - '4'
 target_platform:

--- a/README.md
+++ b/README.md
@@ -209,10 +209,17 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
+              <td>linux_64_microarch_level1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1973&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/suitesparse-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/suitesparse-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level1" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_microarch_level3</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1973&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/suitesparse-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level3" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+microarch_level:
+  - 1 # [linux64]
+  - 3 # [linux64]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -62,7 +62,7 @@ outputs:
       build:
         - if: target_platform == "linux-64"
           then:
-            - x86_64-microarch-level ==  ${{ microarch_level }} 
+            - x86_64-microarch-level ==${{ microarch_level }}
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - ${{ compiler('fortran') }}
@@ -106,7 +106,7 @@ outputs:
       build:
         - if: target_platform == "linux-64"
           then:
-            - x86_64-microarch-level ==  ${{ microarch_level }} 
+            - x86_64-microarch-level ==${{ microarch_level }}
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - ${{ compiler('fortran') }}
@@ -136,7 +136,7 @@ outputs:
       build:
         - if: target_platform == "linux-64"
           then:
-            - x86_64-microarch-level ==  ${{ microarch_level }} 
+            - x86_64-microarch-level ==${{ microarch_level }}
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -165,7 +165,7 @@ outputs:
       build:
         - if: target_platform == "linux-64"
           then:
-            - x86_64-microarch-level ==  ${{ microarch_level }} 
+            - x86_64-microarch-level ==${{ microarch_level }}
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -194,7 +194,7 @@ outputs:
       build:
         - if: target_platform == "linux-64"
           then:
-            - x86_64-microarch-level ==  ${{ microarch_level }} 
+            - x86_64-microarch-level ==${{ microarch_level }}
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -225,7 +225,7 @@ outputs:
       build:
         - if: target_platform == "linux-64"
           then:
-            - x86_64-microarch-level ==  ${{ microarch_level }} 
+            - x86_64-microarch-level ==${{ microarch_level }}
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - ${{ compiler('cxx') }}
@@ -267,7 +267,7 @@ outputs:
       build:
         - if: target_platform == "linux-64"
           then:
-            - x86_64-microarch-level ==  ${{ microarch_level }} 
+            - x86_64-microarch-level ==${{ microarch_level }}
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -296,7 +296,7 @@ outputs:
       build:
         - if: target_platform == "linux-64"
           then:
-            - x86_64-microarch-level ==  ${{ microarch_level }} 
+            - x86_64-microarch-level ==${{ microarch_level }}
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -331,7 +331,7 @@ outputs:
       build:
         - if: target_platform == "linux-64"
           then:
-            - x86_64-microarch-level ==  ${{ microarch_level }} 
+            - x86_64-microarch-level ==${{ microarch_level }}
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -376,7 +376,7 @@ outputs:
       build:
         - if: target_platform == "linux-64"
           then:
-            - x86_64-microarch-level ==  ${{ microarch_level }} 
+            - x86_64-microarch-level ==${{ microarch_level }}
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -405,7 +405,7 @@ outputs:
       build:
         - if: target_platform == "linux-64"
           then:
-            - x86_64-microarch-level ==  ${{ microarch_level }} 
+            - x86_64-microarch-level ==${{ microarch_level }}
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - ${{ compiler('cxx') }}
@@ -443,7 +443,7 @@ outputs:
       build:
         - if: target_platform == "linux-64"
           then:
-            - x86_64-microarch-level ==  ${{ microarch_level }} 
+            - x86_64-microarch-level ==${{ microarch_level }}
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -472,7 +472,7 @@ outputs:
       build:
         - if: target_platform == "linux-64"
           then:
-            - x86_64-microarch-level ==  ${{ microarch_level }} 
+            - x86_64-microarch-level ==${{ microarch_level }}
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -511,7 +511,7 @@ outputs:
       build:
         - if: target_platform == "linux-64"
           then:
-            - x86_64-microarch-level ==  ${{ microarch_level }} 
+            - x86_64-microarch-level ==${{ microarch_level }}
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - ${{ compiler('cxx') }}
@@ -544,7 +544,7 @@ outputs:
       build:
         - if: target_platform == "linux-64"
           then:
-            - x86_64-microarch-level ==  ${{ microarch_level }} 
+            - x86_64-microarch-level ==${{ microarch_level }}
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -576,7 +576,7 @@ outputs:
       build:
         - if: target_platform == "linux-64"
           then:
-            - x86_64-microarch-level ==  ${{ microarch_level }} 
+            - x86_64-microarch-level ==${{ microarch_level }}
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - ${{ compiler('cxx') }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,3 +1,4 @@
+
 context:
   version: "7.10.1"
 
@@ -10,7 +11,9 @@ source:
   sha256: 9e2974e22dba26a3cffe269731339ae8e01365cfe921b06be6359902bd05862c
 
 build:
-  number: 0
+  number: 1
+  variant:
+    down_prioritize_variant: ${{ 1 if microarch_level == "1" else 0  }}
   string: ss${{ version | replace('.', '') }}_h${{ hash }}
 
 outputs:
@@ -27,6 +30,9 @@ outputs:
           SUBPKG_DIR: SuiteSparse_config
     requirements:
       build:
+        - if: target_platform == "linux-64"
+          then:
+            - x86_64-microarch-level ==  ${{ microarch_level }} 
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - ${{ compiler('fortran') }}
@@ -68,6 +74,9 @@ outputs:
           SUBPKG_DIR: AMD
     requirements:
       build:
+        - if: target_platform == "linux-64"
+          then:
+            - x86_64-microarch-level ==  ${{ microarch_level }} 
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - ${{ compiler('fortran') }}
@@ -95,6 +104,9 @@ outputs:
           SUBPKG_DIR: BTF
     requirements:
       build:
+        - if: target_platform == "linux-64"
+          then:
+            - x86_64-microarch-level ==  ${{ microarch_level }} 
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -121,6 +133,9 @@ outputs:
           SUBPKG_DIR: CAMD
     requirements:
       build:
+        - if: target_platform == "linux-64"
+          then:
+            - x86_64-microarch-level ==  ${{ microarch_level }} 
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -147,6 +162,9 @@ outputs:
           SUBPKG_DIR: CCOLAMD
     requirements:
       build:
+        - if: target_platform == "linux-64"
+          then:
+            - x86_64-microarch-level ==  ${{ microarch_level }} 
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -175,6 +193,9 @@ outputs:
           SUBPKG_DIR: CHOLMOD
     requirements:
       build:
+        - if: target_platform == "linux-64"
+          then:
+            - x86_64-microarch-level ==  ${{ microarch_level }} 
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - ${{ compiler('cxx') }}
@@ -214,6 +235,9 @@ outputs:
           SUBPKG_DIR: COLAMD
     requirements:
       build:
+        - if: target_platform == "linux-64"
+          then:
+            - x86_64-microarch-level ==  ${{ microarch_level }} 
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -240,6 +264,9 @@ outputs:
           SUBPKG_DIR: CXSparse
     requirements:
       build:
+        - if: target_platform == "linux-64"
+          then:
+            - x86_64-microarch-level ==  ${{ microarch_level }} 
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -272,6 +299,9 @@ outputs:
           SUBPKG_DIR: KLU
     requirements:
       build:
+        - if: target_platform == "linux-64"
+          then:
+            - x86_64-microarch-level ==  ${{ microarch_level }} 
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -314,6 +344,9 @@ outputs:
           SUBPKG_DIR: LDL
     requirements:
       build:
+        - if: target_platform == "linux-64"
+          then:
+            - x86_64-microarch-level ==  ${{ microarch_level }} 
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -340,6 +373,9 @@ outputs:
           SUBPKG_DIR: ParU
     requirements:
       build:
+        - if: target_platform == "linux-64"
+          then:
+            - x86_64-microarch-level ==  ${{ microarch_level }} 
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - ${{ compiler('cxx') }}
@@ -375,6 +411,9 @@ outputs:
           SUBPKG_DIR: RBio
     requirements:
       build:
+        - if: target_platform == "linux-64"
+          then:
+            - x86_64-microarch-level ==  ${{ microarch_level }} 
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -401,6 +440,9 @@ outputs:
           SUBPKG_DIR: SPEX
     requirements:
       build:
+        - if: target_platform == "linux-64"
+          then:
+            - x86_64-microarch-level ==  ${{ microarch_level }} 
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -437,6 +479,9 @@ outputs:
           SUBPKG_DIR: SPQR
     requirements:
       build:
+        - if: target_platform == "linux-64"
+          then:
+            - x86_64-microarch-level ==  ${{ microarch_level }} 
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - ${{ compiler('cxx') }}
@@ -467,6 +512,9 @@ outputs:
           SUBPKG_DIR: UMFPACK
     requirements:
       build:
+        - if: target_platform == "linux-64"
+          then:
+            - x86_64-microarch-level ==  ${{ microarch_level }} 
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - cmake
@@ -496,6 +544,9 @@ outputs:
           SUBPKG_DIR: Mongoose
     requirements:
       build:
+        - if: target_platform == "linux-64"
+          then:
+            - x86_64-microarch-level ==  ${{ microarch_level }} 
         - ${{ compiler('c') }}
         - ${{ stdlib('c') }}
         - ${{ compiler('cxx') }}


### PR DESCRIPTION
Checklist
* [ x ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ x ] Bumped the build number (if the version is unchanged)
* [ x ] Ensured the license file is being packaged.

the Suitesparse libaries greatly benifit from modern avx and fma instruction set extentions, so greate seperate varients for both v1 and v3 microarch level of x86-64. 

This is my first contribution to conda-forge so hopefully i did everything correctly and the resulting packages will be generated correctly with the right dependencies but from what i at least can see this all looks okay. 